### PR TITLE
python ws.call 並列処理

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,36 @@ from datetime import datetime, timedelta, timezone
 import asyncio
 import pytest
 
-if __name__ == "__main__":
+async def obs_screenshot(source):
+    for i in range(0,len(config_runningdata['locale'][config_runningdata['locale']['lang']]['scene-list'])):
+        print(' ', end='')
+    logger.debug(f'- {config_runningdata['locale'][config_runningdata['locale']['lang']]['source-name']}: {source['sourceName']}')
+    source_name=source['sourceName']
+
+    if active_scene == scene_name and source['sceneItemEnabled']:
+        # https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#getsourcescreenshot
+        screenshot_item={
+            'sourceName':source_name,
+            'imageFormat':config_runningdata['SaveSourceScreenshot']['imageFormat'],
+            'imageFilePath':config_runningdata['SaveSourceScreenshot']['imageFilePath']
+            .replace( '${source_name}', source_name )
+            .replace( '${time}', str(int(time.time())) )
+        }
+
+        screenshot = ws.call(requests.SaveSourceScreenshot(
+            sourceName=screenshot_item.get('sourceName'),
+            imageFormat=screenshot_item.get('imageFormat'),
+            imageFilePath=screenshot_item.get('imageFilePath'),
+        ))
+
+        if screenshot.status:
+            logger.info(f'Caputured: {screenshot_item.get('sourceName')}')
+        else:
+            logger.error(f'Error: {screenshot_item.get('sourceName')}')
+        logger.debug(f'Item: {screenshot}')
+
+
+async def main():
     # workdir: set to current dir
     workdir = os.path.dirname(__file__).replace('\\', '/')
 
@@ -165,35 +194,13 @@ if __name__ == "__main__":
                 continue
 
             sources = ws.call(requests.GetSceneItemList(sceneName=scene_name))
-            for source in sources.getSceneItems():
-                for i in range(0,len(config_runningdata['locale'][config_runningdata['locale']['lang']]['scene-list'])):
-                    print(' ', end='')
-                logger.debug(f'- {config_runningdata['locale'][config_runningdata['locale']['lang']]['source-name']}: {source['sourceName']}')
-                source_name=source['sourceName']
-
-                if active_scene == scene_name and source['sceneItemEnabled']:
-                    # https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#getsourcescreenshot
-                    screenshot_item={
-                        'sourceName':source_name,
-                        'imageFormat':config_runningdata['SaveSourceScreenshot']['imageFormat'],
-                        'imageFilePath':config_runningdata['SaveSourceScreenshot']['imageFilePath']
-                        .replace( '${source_name}', source_name )
-                        .replace( '${time}', str(int(time.time())) )
-                    }
-                    screenshot = ws.call(requests.SaveSourceScreenshot(
-                        sourceName=screenshot_item.get('sourceName'),
-                        imageFormat=screenshot_item.get('imageFormat'),
-                        imageFilePath=screenshot_item.get('imageFilePath'),
-                    ))
-
-                    if screenshot.status:
-                        logger.info(f'Caputured: {screenshot_item.get('sourceName')}')
-                    else:
-                        logger.error(f'Error: {screenshot_item.get('sourceName')}')
-                    logger.debug(f'Item: {screenshot}')
-
+            tasks = [obs_screenshot(i) for i in sources.getSceneItems()]
+            await asyncio.gather(*tasks)
     ws.disconnect()
     logger.info(f'Disconnected from OBS')
 
     time.sleep(1)
     exit(0)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import getpass
 from sys import exit
 import os
 from datetime import datetime, timedelta, timezone
+import asyncio
 import pytest
 
 if __name__ == "__main__":


### PR DESCRIPTION
PythonでWebSocket（ws.callなど）を並列処理するには、通信の待ち時間を効率化する非同期処理（asyncio） またはマルチスレッド処理（concurrent.futures） を使用します。I/O待ちが主なボトルネックとなるWebSocket通信では、asyncioを使うのが軽量かつ一般的です。ここでは、代表的な[2](https://uepon.hatenadiary.com/entry/2018/12/28/203627)つの実装アプローチを解説します。

1. asyncio を使用した非同期並列処理（推奨）通信の「待ち」時間を利用して複数のリクエストを同時に処理します。PythonのWebSocketライブラリ（websockets など）と非常に相性が良い方法です。

```python
import asyncio

async def call_ws(id):
    # 疑似的な ws.call 処理
    print(f"Start: {id}")
    await asyncio.sleep(2)  # サーバーからの応答待ちを想定
    print(f"End: {id}")
    return f"Result {id}"

async def main():
    # 複数の call を同時に実行するタスクを作成
    tasks = [call_ws(i) for i in range(5)]
    
    # asyncio.gather で並列（同時）実行し、結果を待つ
    results = await asyncio.gather(*tasks)
    print(results)

# 実行
asyncio.run(main())
``` 

2. ThreadPoolExecutor を使用したマルチスレッド処理既存の同期型関数（ws.call が同期ブロッキング処理の場合）を一気に実行したい場合は、マルチスレッドを活用します。

```python
import concurrent.futures
import time

def call_ws(id):
    # 同期型の ws.call 処理
    print(f"Start: {id}")
    time.sleep(2)  # 擬似的な通信時間
    return f"Result {id}"

def main():
    # 最大5つのスレッドで並列処理を実行
    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
        futures = [executor.submit(call_ws, i) for i in range(5)]
        
        # 結果を取得
        results = [f.result() for f in concurrent.futures.as_completed(futures)]
        print(results)

# 実行
main()
``` 